### PR TITLE
Removing IComponent

### DIFF
--- a/ComponentManager.cs
+++ b/ComponentManager.cs
@@ -7,13 +7,13 @@ namespace ECSLight
 {
 	public class ComponentManager : IComponentManager
 	{
-		private readonly Dictionary<IEntity, Dictionary<Type, IComponent>> _components;
+		private readonly Dictionary<IEntity, Dictionary<Type, object>> _components;
 		private readonly ISetManager _setManager;
-		private static readonly IEnumerator<IComponent> EmptyComponents = new List<IComponent>(0).GetEnumerator();
+		private static readonly IEnumerator<object> EmptyComponents = new List<object>(0).GetEnumerator();
 
 		public ComponentManager(ISetManager setManager)
 		{
-			_components = new Dictionary<IEntity, Dictionary<Type, IComponent>>();
+			_components = new Dictionary<IEntity, Dictionary<Type, object>>();
 			_setManager = setManager;
 		}
 
@@ -23,13 +23,13 @@ namespace ECSLight
 		/// <typeparam name="TComponent">Type of component to attach.</typeparam>
 		/// <param name="entity">IEntity to which the component should be attached.</param>
 		/// <param name="component">Component to attach to the entity.</param>
-		public void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class, IComponent
+		public void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class
 		{
 			var type = typeof(TComponent);
 
 			// add component to entity
 			if (!_components.ContainsKey(entity))
-				_components[entity] = new Dictionary<Type, IComponent>(1);
+				_components[entity] = new Dictionary<Type, object>(1);
 			var replaceComponent = _components[entity].ContainsKey(type);
 			var old = replaceComponent ? _components[entity][type] : null;
 
@@ -47,7 +47,7 @@ namespace ECSLight
 		/// <typeparam name="TComponent">Type of component that may be attached to the entity.</typeparam>
 		/// <param name="entity">IEntity to check if component is attached.</param>
 		/// <returns>`true` if the entity has a component of that type attached</returns>
-		public bool ContainsComponent<TComponent>(IEntity entity) where TComponent : IComponent
+		public bool ContainsComponent<TComponent>(IEntity entity)
 		{
 			var type = typeof(TComponent);
 			return ContainsComponent(entity, type);
@@ -73,7 +73,7 @@ namespace ECSLight
 		/// <typeparam name="TComponent">Type of component to remove.</typeparam>
 		/// <param name="entity">Which entity owns the component?</param>
 		/// <returns>`null` if no component is attached</returns>
-		public TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class, IComponent
+		public TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class
 		{
 			if (!_components.ContainsKey(entity))
 				return null;
@@ -87,7 +87,7 @@ namespace ECSLight
 		/// </summary>
 		/// <typeparam name="TComponent">Type of component to remove from entitiy.</typeparam>
 		/// <param name="entity">IEntity from which component is removed.</param>
-		public void RemoveComponent<TComponent>(IEntity entity) where TComponent : class, IComponent
+		public void RemoveComponent<TComponent>(IEntity entity) where TComponent : class
 		{
 			var type = typeof(TComponent);
 			RemoveComponent(entity, type);
@@ -110,7 +110,7 @@ namespace ECSLight
 		/// <summary>
 		/// Enumerate through the components in an entity.
 		/// </summary>
-		public IEnumerator<IComponent> GetEnumerator(IEntity entity)
+		public IEnumerator<object> GetEnumerator(IEntity entity)
 		{
 			if (!_components.ContainsKey(entity))
 				return EmptyComponents;

--- a/ECSLight Unity/ECSLight Unity.csproj
+++ b/ECSLight Unity/ECSLight Unity.csproj
@@ -56,9 +56,6 @@
     <Compile Include="..\EntitySet.cs">
       <Link>EntitySet.cs</Link>
     </Compile>
-    <Compile Include="..\IComponent.cs">
-      <Link>IComponent.cs</Link>
-    </Compile>
     <Compile Include="..\IComponentManager.cs">
       <Link>IComponentManager.cs</Link>
     </Compile>

--- a/ECSLight.csproj
+++ b/ECSLight.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EntitySet.cs" />
-    <Compile Include="IComponent.cs" />
     <Compile Include="ComponentManager.cs" />
     <Compile Include="Context.cs" />
     <Compile Include="Entity.cs" />

--- a/Entity.cs
+++ b/Entity.cs
@@ -43,7 +43,7 @@ namespace ECSLight
 		/// Add a component to this entity.
 		/// Updates context's entity sets.
 		/// </summary>
-		public void Add<TComponent>(TComponent component) where TComponent : class, IComponent
+		public void Add<TComponent>(TComponent component) where TComponent : class
 		{
 			_componentManager.AddComponent(this, component);
 		}
@@ -51,7 +51,7 @@ namespace ECSLight
 		/// <summary>
 		/// Check if this entity has a component type.
 		/// </summary>
-		public bool Contains<TComponent>() where TComponent : IComponent
+		public bool Contains<TComponent>()
 		{
 			return _componentManager.ContainsComponent<TComponent>(this);
 		}
@@ -68,7 +68,7 @@ namespace ECSLight
 		/// Get the component attached to this entity.
 		/// </summary>
 		/// <returns>null if the component is not attached</returns>
-		public TComponent Get<TComponent>() where TComponent : class, IComponent
+		public TComponent Get<TComponent>() where TComponent : class
 		{
 			return _componentManager.ComponentFrom<TComponent>(this);
 		}
@@ -78,7 +78,7 @@ namespace ECSLight
 		/// Updates the context's entity sets.
 		/// </summary>
 		/// <typeparam name="TComponent"></typeparam>
-		public void Remove<TComponent>() where TComponent : class, IComponent
+		public void Remove<TComponent>() where TComponent : class
 		{
 			_componentManager.RemoveComponent<TComponent>(this);
 		}
@@ -86,7 +86,7 @@ namespace ECSLight
 		/// <summary>
 		/// Enumerate through this entity's components.
 		/// </summary>
-		public IEnumerator<IComponent> GetEnumerator()
+		public IEnumerator<object> GetEnumerator()
 		{
 			return _componentManager.GetEnumerator(this);
 		}
@@ -95,7 +95,7 @@ namespace ECSLight
 		{
 			// Unity 3.5 target doesnt support IEnumerable to string[], for string.Join() below
 			var componentStrings = new List<string>();
-			foreach(var component in this) {
+			foreach (var component in this) {
 				componentStrings.Add(component.ToString());
 			}
 			var components = string.Join(", ", componentStrings.ToArray());

--- a/EntityManager.cs
+++ b/EntityManager.cs
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/EntitySet.cs
+++ b/EntitySet.cs
@@ -10,8 +10,8 @@ namespace ECSLight
 	{
 		public Predicate<IEntity> Predicate { get; }
 		public int Count => _entities.Count;
-		public event Action<IEntity, IComponent, IComponent> OnAdded;
-		public event Action<IEntity, IComponent, IComponent> OnRemoved;
+		public event Action<IEntity, object, object> OnAdded;
+		public event Action<IEntity, object, object> OnRemoved;
 
 		private readonly HashSet<IEntity> _entities = new HashSet<IEntity>();
 
@@ -30,13 +30,13 @@ namespace ECSLight
 			return _entities.Contains(item);
 		}
 
-		public void Add(IEntity item, IComponent old = null, IComponent component = null)
+		public void Add(IEntity item, object old = null, object component = null)
 		{
 			_entities.Add(item);
 			OnAdded?.Invoke(item, old, component);
 		}
 
-		public bool Remove(IEntity item, IComponent old, IComponent component = null)
+		public bool Remove(IEntity item, object old, object component = null)
 		{
 			var hadEntity = _entities.Remove(item);
 			if (hadEntity)

--- a/IComponent.cs
+++ b/IComponent.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
-
-namespace ECSLight
-{
-	public interface IComponent
-	{
-	}
-}

--- a/IComponentManager.cs
+++ b/IComponentManager.cs
@@ -7,12 +7,12 @@ namespace ECSLight
 {
 	public interface IComponentManager
 	{
-		void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class, IComponent;
-		TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class, IComponent;
-		bool ContainsComponent<TComponent>(IEntity entity) where TComponent : IComponent;
+		void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class;
+		TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class;
+		bool ContainsComponent<TComponent>(IEntity entity);
 		bool ContainsComponent(IEntity entity, Type type);
-		void RemoveComponent<TComponent>(IEntity entity) where TComponent : class, IComponent;
+		void RemoveComponent<TComponent>(IEntity entity) where TComponent : class;
 		void RemoveComponent(IEntity entity, Type type);
-		IEnumerator<IComponent> GetEnumerator(IEntity entity);
+		IEnumerator<object> GetEnumerator(IEntity entity);
 	}
 }

--- a/IEntity.cs
+++ b/IEntity.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace ECSLight
 {
-	public interface IEntity : IEnumerable<IComponent>
+	public interface IEntity : IEnumerable<object>
 	{
 		/// <summary>
 		/// End the lifecycle of this entity.
@@ -16,12 +16,12 @@ namespace ECSLight
 		/// Add a component to this entity.
 		/// Updates context's entity sets.
 		/// </summary>
-		void Add<TComponent>(TComponent component) where TComponent : class, IComponent;
+		void Add<TComponent>(TComponent component) where TComponent : class;
 
 		/// <summary>
 		/// Check if this entity has a component type.
 		/// </summary>
-		bool Contains<TComponent>() where TComponent : IComponent;
+		bool Contains<TComponent>();
 
 		/// <summary>
 		/// Check if this entity has a component type.
@@ -32,13 +32,13 @@ namespace ECSLight
 		/// Get the component attached to this entity.
 		/// </summary>
 		/// <returns>null if the component is not attached</returns>
-		TComponent Get<TComponent>() where TComponent : class, IComponent;
+		TComponent Get<TComponent>() where TComponent : class;
 
 		/// <summary>
 		/// Remove the component from this entity.
 		/// Updates the context's entity sets.
 		/// </summary>
 		/// <typeparam name="TComponent"></typeparam>
-		void Remove<TComponent>() where TComponent : class, IComponent;
+		void Remove<TComponent>() where TComponent : class;
 	}
 }

--- a/ISetManager.cs
+++ b/ISetManager.cs
@@ -8,8 +8,8 @@ namespace ECSLight
 	{
 		EntitySet CreateSet(Predicate<IEntity> predicate);
 		void RemoveSet(EntitySet set);
-		void ComponentAdded(IEntity entity, IComponent component);
-		void ComponentReplaced(IEntity entity, IComponent old, IComponent component);
-		void ComponentRemoved(IEntity entity, IComponent component);
+		void ComponentAdded(IEntity entity, object component);
+		void ComponentReplaced(IEntity entity, object oldComponent, object component);
+		void ComponentRemoved(IEntity entity, object oldComponent);
 	}
 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
-﻿using System.Resources;
+﻿// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
+
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Resources;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/SetManager.cs
+++ b/SetManager.cs
@@ -55,22 +55,22 @@ namespace ECSLight
 		/// <summary>
 		/// Add entity to all matching sets, remove from any unmatching sets.
 		/// </summary>
-		public void ComponentAdded(IEntity entity, IComponent component)
+		public void ComponentAdded(IEntity entity, object component)
 		{
 			UpdateSets(entity, null, component);
 		}
 
-		public void ComponentReplaced(IEntity entity, IComponent old, IComponent component)
+		public void ComponentReplaced(IEntity entity, object oldComponent, object component)
 		{
-			UpdateSets(entity, old, component);
+			UpdateSets(entity, oldComponent, component);
 		}
 
-		public void ComponentRemoved(IEntity entity, IComponent old)
+		public void ComponentRemoved(IEntity entity, object oldComponent)
 		{
-			UpdateSets(entity, old, null);
+			UpdateSets(entity, oldComponent, null);
 		}
 
-		private void UpdateSets(IEntity entity, IComponent old, IComponent component)
+		private void UpdateSets(IEntity entity, object old, object component)
 		{
 			foreach (var kvp in _entitySets) {
 				var set = kvp.Value;

--- a/Tests/ComponentManagerTests.cs
+++ b/Tests/ComponentManagerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
 
-using System.Collections;
 using ECSLight;
 using NUnit.Framework;
 using Tests.Stubs;

--- a/Tests/EntityManagerTests.cs
+++ b/Tests/EntityManagerTests.cs
@@ -16,7 +16,7 @@ namespace Tests
 		{
 			var entity = new StubEntity();
 			var entityManager = new EntityManager(new List<IEntity> {entity}, new StubComponentManager());
-			var enumerable = (IEnumerable)entityManager;
+			var enumerable = (IEnumerable) entityManager;
 			var enumerator = enumerable.GetEnumerator();
 			Assert.IsTrue(enumerator.MoveNext());
 			Assert.AreSame(entity, enumerator.Current);

--- a/Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Tests/Stubs/AComponent.cs
+++ b/Tests/Stubs/AComponent.cs
@@ -1,10 +1,8 @@
 // Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
 
-using ECSLight;
-
 namespace Tests.Stubs
 {
-	internal class AComponent : IComponent
+	internal class AComponent
 	{
 		public string Name;
 

--- a/Tests/Stubs/BComponent.cs
+++ b/Tests/Stubs/BComponent.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (C) 2017 Robert A. Wallis, All Rights Reserved.
 
-using ECSLight;
-
 namespace Tests.Stubs
 {
-	internal class BComponent : IComponent
+	internal class BComponent
 	{
 	}
 }

--- a/Tests/Stubs/StubComponentManager.cs
+++ b/Tests/Stubs/StubComponentManager.cs
@@ -8,18 +8,18 @@ namespace Tests.Stubs
 {
 	internal class StubComponentManager : IComponentManager
 	{
-		private static IEnumerator<IComponent> EmptyEnumerator = new List<IComponent>().GetEnumerator();
+		private static readonly IEnumerator<object> EmptyEnumerator = new List<object>().GetEnumerator();
 
-		public void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class, IComponent
+		public void AddComponent<TComponent>(IEntity entity, TComponent component) where TComponent : class
 		{
 		}
 
-		public TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class, IComponent
+		public TComponent ComponentFrom<TComponent>(IEntity entity) where TComponent : class
 		{
 			return null;
 		}
 
-		public bool ContainsComponent<TComponent>(IEntity entity) where TComponent : IComponent
+		public bool ContainsComponent<TComponent>(IEntity entity)
 		{
 			return false;
 		}
@@ -29,7 +29,7 @@ namespace Tests.Stubs
 			return false;
 		}
 
-		public void RemoveComponent<TComponent>(IEntity entity) where TComponent : class, IComponent
+		public void RemoveComponent<TComponent>(IEntity entity) where TComponent : class
 		{
 		}
 
@@ -37,7 +37,7 @@ namespace Tests.Stubs
 		{
 		}
 
-		public IEnumerator<IComponent> GetEnumerator(IEntity entity)
+		public IEnumerator<object> GetEnumerator(IEntity entity)
 		{
 			return EmptyEnumerator;
 		}

--- a/Tests/Stubs/StubEntity.cs
+++ b/Tests/Stubs/StubEntity.cs
@@ -9,9 +9,9 @@ namespace Tests.Stubs
 {
 	internal class StubEntity : IEntity
 	{
-		private static IEnumerator<IComponent> Empty = new List<IComponent>().GetEnumerator();
+		private static readonly IEnumerator<object> Empty = new List<object>().GetEnumerator();
 
-		public IEnumerator<IComponent> GetEnumerator()
+		public IEnumerator<object> GetEnumerator()
 		{
 			return Empty;
 		}
@@ -25,11 +25,11 @@ namespace Tests.Stubs
 		{
 		}
 
-		public void Add<TComponent>(TComponent component) where TComponent : class, IComponent
+		public void Add<TComponent>(TComponent component) where TComponent : class
 		{
 		}
 
-		public bool Contains<TComponent>() where TComponent : IComponent
+		public bool Contains<TComponent>()
 		{
 			return false;
 		}
@@ -39,12 +39,12 @@ namespace Tests.Stubs
 			return false;
 		}
 
-		public TComponent Get<TComponent>() where TComponent : class, IComponent
+		public TComponent Get<TComponent>() where TComponent : class
 		{
 			return null;
 		}
 
-		public void Remove<TComponent>() where TComponent : class, IComponent
+		public void Remove<TComponent>() where TComponent : class
 		{
 		}
 	}

--- a/Tests/Stubs/StubSetManager.cs
+++ b/Tests/Stubs/StubSetManager.cs
@@ -22,15 +22,15 @@ namespace Tests.Stubs
 			RemoveSetSet = set;
 		}
 
-		public void ComponentAdded(IEntity entity, IComponent component)
+		public void ComponentAdded(IEntity entity, object component)
 		{
 		}
 
-		public void ComponentReplaced(IEntity entity, IComponent old, IComponent component)
+		public void ComponentReplaced(IEntity entity, object oldComponent, object component)
 		{
 		}
 
-		public void ComponentRemoved(IEntity entity, IComponent component)
+		public void ComponentRemoved(IEntity entity, object oldComponent)
 		{
 		}
 	}


### PR DESCRIPTION
`IComponent` is an empty interface.
A good reason for an empty interface it to distinguish objects from eachother by type.  No existing code requires looking through a set of objects to make sure they are IComponents.
Components in ECS should theoretically the same as a class member, data with no logic.

> `IComponent` is an empty interface.

Therefore components can be any `object`.

A core goal of ECS Light is being "lightweight".  Deleting unnecessary code makes it more lightweight. 
 `IComponent` is unnecessary code.
Therefore it should be deleted.

&#8718;